### PR TITLE
feat(mod-chart): add `index.duration` so that now `gridWidth` in `BarChart` can be drawn independently (get rid of the effect of interval)

### DIFF
--- a/examples/main.ts
+++ b/examples/main.ts
@@ -1,4 +1,4 @@
-import { CarEngine, Color, Rect, Shader, Text } from 'newcar'
+import { CarEngine, Color, Shader, Text } from 'newcar'
 import { Angle, Brace } from '@newcar/mod-geometry'
 import { BarChart, BubbleChart, ChartDataUnit, ChartUtil, LineChart, MixedChart, ScatterChart } from '@newcar/mod-chart'
 import { Markdown } from '@newcar/mod-markdown'
@@ -295,14 +295,14 @@ const sceneChart5 = new nc.Scene(
         data: {
           labels: ChartUtil.dateSequence(
             DateTime.fromISO('2021-02-01').setLocale('en-US'),
-            Duration.fromObject({ months: 4 }),
+            Duration.fromObject({ months: 3.5 }),
             'month',
-            1,
+            0.5,
           ),
           datasets: [
             {
               label: 'Bar 1',
-              data: ChartUtil.dataUnits([-14, 5, -4, 18]),
+              data: ChartUtil.dataUnits([-14, 5, -4, 18, 6, 6, 6]),
               style: {
                 backgroundColor: Color.parse('#FFFF00').withAlpha(0.2),
                 borderColor: Color.parse('#FFFF00'),
@@ -327,6 +327,24 @@ const sceneChart5 = new nc.Scene(
                   style: {
                     backgroundColor: Color.rgba(255, 205, 86, 0.2),
                     borderColor: Color.rgba(255, 205, 86),
+                  },
+                }),
+                new ChartDataUnit(5, {
+                  style: {
+                    backgroundColor: Color.rgba(75, 192, 192, 0.2),
+                    borderColor: Color.rgba(75, 192, 192),
+                  },
+                }),
+                new ChartDataUnit(5, {
+                  style: {
+                    backgroundColor: Color.rgba(75, 192, 192, 0.2),
+                    borderColor: Color.rgba(75, 192, 192),
+                  },
+                }),
+                new ChartDataUnit(5, {
+                  style: {
+                    backgroundColor: Color.rgba(75, 192, 192, 0.2),
+                    borderColor: Color.rgba(75, 192, 192),
                   },
                 }),
                 new ChartDataUnit(5, {

--- a/mods/mod-chart/src/utils/chartUtil.ts
+++ b/mods/mod-chart/src/utils/chartUtil.ts
@@ -6,8 +6,9 @@
  * @description
  * This module provides utility functions for the chart widgets.
  */
-import type { DateTime, DateTimeUnit, Duration } from 'luxon'
-import type { ChartData, ChartDataOptions } from '../widgets'
+import type { DateTime, DateTimeUnit } from 'luxon'
+import { Duration } from 'luxon'
+import type { ChartData, ChartDataOptions, DateTimeWithDuration } from '../widgets'
 import { ChartDataUnit } from '../widgets'
 
 /**
@@ -34,9 +35,13 @@ export function dataUnits<ChartStyle>(data: (number | ChartData)[], options?: Ch
  * @param intervalUnit
  * @param interval
  */
-export function dateSequence(start: DateTime, duration: Duration, intervalUnit: DateTimeUnit, interval: number = 1): DateTime[] {
+export function dateSequence(start: DateTime, duration: Duration, intervalUnit: DateTimeUnit, interval: number = 1): DateTimeWithDuration[] {
   const sequence = []
   for (let i = 0; start.startOf(intervalUnit).plus({ [intervalUnit]: i }) < start.startOf(intervalUnit).plus(duration); i += interval)
     sequence.push(start.startOf(intervalUnit).plus({ [intervalUnit]: i }))
-  return sequence
+  return sequence.map((date) => {
+    const dateWithPeriod = date as DateTimeWithDuration
+    dateWithPeriod.duration = Duration.fromObject({ [intervalUnit]: interval })
+    return dateWithPeriod
+  })
 }

--- a/mods/mod-chart/src/widgets/barChart.ts
+++ b/mods/mod-chart/src/widgets/barChart.ts
@@ -128,14 +128,14 @@ export class BarChart extends BaseSimpleChart {
       set.style.border ??= this.data.style?.border ?? true
 
       if (this.layout.indexAxis === 'x') {
-        const gridSize = this.layout.index.interval
-          / (this.layout.index.max - this.layout.index.min) * this.layout.size.width
-        const categorySize = gridSize * this.categoryPercentage
-        const barSize = (categorySize / this.data.datasets.length) * this.barPercentage
         return set.data.map((unit) => {
+          const gridSize = (unit.indexDuration() ?? this.layout.index.interval)
+            / (this.layout.index.max - this.layout.index.min) * this.layout.size.width
+          const categorySize = gridSize * this.categoryPercentage
+          const barSize = (categorySize / this.data.datasets.length) * this.barPercentage
           return new Rect(
             [
-              (unit.index - this.layout.index.interval / 2 - this.layout.index.min)
+              (unit.index - (unit.indexDuration() ?? this.layout.index.interval) / 2 - this.layout.index.min)
               / (this.layout.index.max - this.layout.index.min) * this.layout.size.width
               + (gridSize - categorySize) / 2 + (setIndex * categorySize) / this.data.datasets.length
               + (categorySize / this.data.datasets.length - barSize) / 2,
@@ -143,7 +143,7 @@ export class BarChart extends BaseSimpleChart {
               / (this.layout.cross.max - this.layout.cross.min),
             ],
             [
-              (unit.index - this.layout.index.interval / 2 - this.layout.index.min)
+              (unit.index - (unit.indexDuration() ?? this.layout.index.interval) / 2 - this.layout.index.min)
               / (this.layout.index.max - this.layout.index.min) * this.layout.size.width
               + (gridSize - categorySize) / 2 + (setIndex * categorySize) / this.data.datasets.length
               + (categorySize / this.data.datasets.length - barSize) / 2
@@ -165,15 +165,15 @@ export class BarChart extends BaseSimpleChart {
         })
       }
       else {
-        const gridSize = this.layout.index.interval
-          / (this.layout.index.max - this.layout.index.min) * this.layout.size.height
-        const categorySize = gridSize * this.categoryPercentage
-        const barSize = (categorySize / this.data.datasets.length) * this.barPercentage
         return set.data.map((unit) => {
+          const gridSize = (unit.indexDuration() ?? this.layout.index.interval)
+            / (this.layout.index.max - this.layout.index.min) * this.layout.size.height
+          const categorySize = gridSize * this.categoryPercentage
+          const barSize = (categorySize / this.data.datasets.length) * this.barPercentage
           return new Rect(
             [
               (0 - this.layout.cross.min) / (this.layout.cross.max - this.layout.cross.min) * this.layout.size.width,
-              (unit.index - this.layout.index.interval / 2 - this.layout.index.min)
+              (unit.index - (unit.indexDuration() ?? this.layout.index.interval) / 2 - this.layout.index.min)
               / (this.layout.index.max - this.layout.index.min) * this.layout.size.height
               + (gridSize - categorySize) / 2
               + (setIndex * categorySize) / this.data.datasets.length
@@ -182,7 +182,7 @@ export class BarChart extends BaseSimpleChart {
             [
               ((unit.cross * this.progress - this.layout.cross.min) * this.layout.size.width)
               / (this.layout.cross.max - this.layout.cross.min),
-              (unit.index - this.layout.index.interval / 2 - this.layout.index.min)
+              (unit.index - (unit.indexDuration() ?? this.layout.index.interval) / 2 - this.layout.index.min)
               / (this.layout.index.max - this.layout.index.min) * this.layout.size.height
               + (gridSize - categorySize) / 2
               + (setIndex * categorySize) / this.data.datasets.length

--- a/mods/mod-chart/src/widgets/chartDataUnit.ts
+++ b/mods/mod-chart/src/widgets/chartDataUnit.ts
@@ -1,5 +1,5 @@
 import { Widget, type WidgetOptions } from '@newcar/core'
-import type { DateTimeUnit } from 'luxon'
+import type { DateTimeUnit, Duration } from 'luxon'
 import { DateTime } from 'luxon'
 
 /**
@@ -16,6 +16,18 @@ export interface ChartDataOptions<ChartStyle> extends WidgetOptions {
 }
 
 /**
+ * DateTimeWithPeriod
+ * @public
+ * @category General
+ * @interface
+ * @extends {DateTime}
+ * @property {Duration} [duration] - Period
+ */
+export interface DateTimeWithDuration extends DateTime {
+  duration?: Duration
+}
+
+/**
  * ChartData
  * @public
  * @category General
@@ -25,7 +37,7 @@ export interface ChartDataOptions<ChartStyle> extends WidgetOptions {
  * @property {number} [weight] - Weight value (display forms may differ depending on the chart type)
  */
 export interface ChartData {
-  index?: number | DateTime
+  index?: number | DateTimeWithDuration
   cross?: number
   weight?: number
 }
@@ -92,6 +104,15 @@ export class ChartDataUnit<ChartStyle> extends Widget {
    */
   indexDate() {
     return <DateTime> (<ChartData> this.value).index
+  }
+
+  /**
+   * returns the index duration value as a number
+   */
+  indexDuration(): number {
+    if (!this.intervalUnit)
+      throw new Error('Interval unit is not set')
+    return (<DateTimeWithDuration> (<ChartData> this.value).index).duration.as(this.intervalUnit)
   }
 
   /**


### PR DESCRIPTION
**Description:**
feat(mod-chart): add `index.duration` so that now `gridWidth` in `BarChart` can be drawn independently (get rid of the effect of interval)

**Checklist:**

- [x]  Code has been reviewed
- [x]  Code complies with the project's code standards and best practices
- [x]  Code has passed all tests
- [x]  Code does not affect the normal use of existing features
- [x]  Documentation has been updated

**Screenshots:**
![image](https://github.com/dromara/newcar/assets/51940778/550fc2fb-f923-4510-8e54-e4c43d163685)