### PR TITLE
feat: `Widget.coordinateChildToParent`, `Widget.range` default implementation, `Widget.calculateRange`, `calculateRange` implementation for widgets with `path`

### DIFF
--- a/mods/mod-chart/src/widgets/lineChart.ts
+++ b/mods/mod-chart/src/widgets/lineChart.ts
@@ -2,6 +2,7 @@ import { Circle } from '@newcar/basic'
 import type { Canvas, CanvasKit, Paint, Path } from 'canvaskit-wasm'
 import type { StrokeCap, StrokeJoin } from '@newcar/utils'
 import { Color, str2BlendMode, str2StrokeCap, str2StrokeJoin } from '@newcar/utils'
+import type { WidgetRange } from '@newcar/core'
 import { bezierControlPoints } from '../utils/bezierControlPoints'
 import type {
   BaseSimpleChartData,
@@ -369,5 +370,15 @@ export class LineChart extends BaseSimpleChart {
   isIn(x: number, y: number): boolean {
     const { x: dx, y: dy } = this.coordinateParentToChild(x, y)
     return super.isIn(x, y) || this.paths.some(path => path.contains(dx, dy))
+  }
+
+  calculateRange(): WidgetRange {
+    const boundsArray = this.paths.map(path => path.computeTightBounds())
+    return [
+      Math.min(...boundsArray.map(bounds => bounds[0])),
+      Math.min(...boundsArray.map(bounds => bounds[1])),
+      Math.max(...boundsArray.map(bounds => bounds[2])),
+      Math.max(...boundsArray.map(bounds => bounds[3])),
+    ]
   }
 }

--- a/mods/mod-chart/src/widgets/lineChart.ts
+++ b/mods/mod-chart/src/widgets/lineChart.ts
@@ -367,7 +367,7 @@ export class LineChart extends BaseSimpleChart {
   }
 
   isIn(x: number, y: number): boolean {
-    const { x: dx, y: dy } = this.transformedPoint(x, y)
+    const { x: dx, y: dy } = this.coordinateParentToChild(x, y)
     return super.isIn(x, y) || this.paths.some(path => path.contains(dx, dy))
   }
 }

--- a/mods/mod-geometry/src/widgets/brace.ts
+++ b/mods/mod-geometry/src/widgets/brace.ts
@@ -61,7 +61,7 @@ export class Brace extends Widget {
   }
 
   isIn(x: number, y: number): boolean {
-    const { x: dx, y: dy } = this.transformedPoint(x, y)
+    const { x: dx, y: dy } = this.coordinateParentToChild(x, y)
     return super.isIn(x, y) || this.path.contains(dx, dy)
   }
 }

--- a/mods/mod-geometry/src/widgets/brace.ts
+++ b/mods/mod-geometry/src/widgets/brace.ts
@@ -1,5 +1,5 @@
 import type { Vector2 } from '@newcar/basic'
-import type { WidgetOptions, WidgetStyle } from '@newcar/core'
+import type { WidgetOptions, WidgetRange, WidgetStyle } from '@newcar/core'
 import { Widget } from '@newcar/core'
 import type { Shader } from '@newcar/utils'
 import { Color } from '@newcar/utils'
@@ -63,5 +63,10 @@ export class Brace extends Widget {
   isIn(x: number, y: number): boolean {
     const { x: dx, y: dy } = this.coordinateParentToChild(x, y)
     return super.isIn(x, y) || this.path.contains(dx, dy)
+  }
+
+  calculateRange(): WidgetRange {
+    const bounds = this.path.computeTightBounds()
+    return [...bounds] as WidgetRange
   }
 }

--- a/mods/mod-math/src/widgets/mathFunction.ts
+++ b/mods/mod-math/src/widgets/mathFunction.ts
@@ -1,4 +1,4 @@
-import type { WidgetOptions, WidgetStyle } from '@newcar/core'
+import type { WidgetOptions, WidgetRange, WidgetStyle } from '@newcar/core'
 import { Widget } from '@newcar/core'
 import type { Shader } from '@newcar/utils'
 import { Color } from '@newcar/utils'
@@ -110,5 +110,10 @@ export class MathFunction extends Widget {
   isIn(x: number, y: number): boolean {
     const { x: dx, y: dy } = this.coordinateParentToChild(x, y)
     return super.isIn(x, y) || this.path.contains(dx, dy)
+  }
+
+  calculateRange(): WidgetRange {
+    const bounds = this.path.computeTightBounds()
+    return [...bounds] as WidgetRange
   }
 }

--- a/mods/mod-math/src/widgets/mathFunction.ts
+++ b/mods/mod-math/src/widgets/mathFunction.ts
@@ -108,7 +108,7 @@ export class MathFunction extends Widget {
   }
 
   isIn(x: number, y: number): boolean {
-    const { x: dx, y: dy } = this.transformedPoint(x, y)
+    const { x: dx, y: dy } = this.coordinateParentToChild(x, y)
     return super.isIn(x, y) || this.path.contains(dx, dy)
   }
 }

--- a/packages/basic/src/widgets/figures/arc.ts
+++ b/packages/basic/src/widgets/figures/arc.ts
@@ -146,12 +146,8 @@ export class Arc extends Figure {
     return super.isIn(x, y) || this.path.contains(dx, dy)
   }
 
-  get range(): WidgetRange {
-    return [
-      this.x - this.radius,
-      this.y - this.radius,
-      this.x + this.radius,
-      this.y + this.radius,
-    ]
+  calculateRange(): WidgetRange {
+    const bounds = this.path.computeTightBounds()
+    return [...bounds] as WidgetRange
   }
 }

--- a/packages/basic/src/widgets/figures/arc.ts
+++ b/packages/basic/src/widgets/figures/arc.ts
@@ -142,7 +142,7 @@ export class Arc extends Figure {
    * @returns True if the point is inside the arc, otherwise false.
    */
   isIn(x: number, y: number): boolean {
-    const { x: dx, y: dy } = this.transformedPoint(x, y)
+    const { x: dx, y: dy } = this.coordinateParentToChild(x, y)
     return super.isIn(x, y) || this.path.contains(dx, dy)
   }
 

--- a/packages/basic/src/widgets/figures/arrow.ts
+++ b/packages/basic/src/widgets/figures/arrow.ts
@@ -1,5 +1,4 @@
 import type { CanvasKit } from 'canvaskit-wasm'
-import type { WidgetRange } from '@newcar/core'
 import type { Vector2 } from '../../utils/vector2'
 import type { FigureOptions, FigureStyle } from './figure'
 import { Figure } from './figure'
@@ -134,12 +133,5 @@ export class Arrow extends Figure {
         this.tip.style.interval = this.style.interval
       }
     }
-  }
-
-  get range(): WidgetRange {
-    return [
-      ...this.from,
-      ...this.to,
-    ]
   }
 }

--- a/packages/basic/src/widgets/figures/line.ts
+++ b/packages/basic/src/widgets/figures/line.ts
@@ -93,10 +93,8 @@ export class Line extends Figure {
     return super.isIn(x, y) || this.path.contains(dx, dy)
   }
 
-  get range(): WidgetRange {
-    return [
-      ...this.from,
-      ...this.to,
-    ]
+  calculateRange(): WidgetRange {
+    const bounds = this.path.computeTightBounds()
+    return [...bounds] as WidgetRange
   }
 }

--- a/packages/basic/src/widgets/figures/line.ts
+++ b/packages/basic/src/widgets/figures/line.ts
@@ -89,7 +89,7 @@ export class Line extends Figure {
   }
 
   isIn(x: number, y: number): boolean {
-    const { x: dx, y: dy } = this.transformedPoint(x, y)
+    const { x: dx, y: dy } = this.coordinateParentToChild(x, y)
     return super.isIn(x, y) || this.path.contains(dx, dy)
   }
 

--- a/packages/basic/src/widgets/figures/path.ts
+++ b/packages/basic/src/widgets/figures/path.ts
@@ -1,4 +1,5 @@
 import type { Canvas, CanvasKit, Path as ckPath } from 'canvaskit-wasm'
+import type { WidgetRange } from '@newcar/core'
 import { $ck } from '@newcar/core'
 import { str2StrokeCap, str2StrokeJoin } from '@newcar/utils'
 import type { FigureOptions, FigureStyle } from './figure'
@@ -119,5 +120,10 @@ export class Path extends Figure {
   isIn(x: number, y: number): boolean {
     const { x: dx, y: dy } = this.coordinateParentToChild(x, y)
     return super.isIn(x, y) || this.path.contains(dx, dy)
+  }
+
+  calculateRange(): WidgetRange {
+    const bounds = this.path.computeTightBounds()
+    return [...bounds] as WidgetRange
   }
 }

--- a/packages/basic/src/widgets/figures/path.ts
+++ b/packages/basic/src/widgets/figures/path.ts
@@ -117,7 +117,7 @@ export class Path extends Figure {
   }
 
   isIn(x: number, y: number): boolean {
-    const { x: dx, y: dy } = this.transformedPoint(x, y)
+    const { x: dx, y: dy } = this.coordinateParentToChild(x, y)
     return super.isIn(x, y) || this.path.contains(dx, dy)
   }
 }

--- a/packages/basic/src/widgets/figures/polygon.ts
+++ b/packages/basic/src/widgets/figures/polygon.ts
@@ -131,12 +131,8 @@ export class Polygon extends Figure {
     return super.isIn(x, y) || this.path.contains(dx, dy)
   }
 
-  get range(): WidgetRange {
-    return [
-      this.x,
-      this.y,
-      Math.max(...this.points.map(point => point[0])),
-      Math.max(...this.points.map(point => point[1])),
-    ]
+  calculateRange(): WidgetRange {
+    const bounds = this.path.computeTightBounds()
+    return [...bounds] as WidgetRange
   }
 }

--- a/packages/basic/src/widgets/figures/polygon.ts
+++ b/packages/basic/src/widgets/figures/polygon.ts
@@ -127,7 +127,7 @@ export class Polygon extends Figure {
    * this.points: [[x0,y0],[x1,y1]......] 多边形的路径
    */
   isIn(x: number, y: number) {
-    const { x: dx, y: dy } = this.transformedPoint(x, y)
+    const { x: dx, y: dy } = this.coordinateParentToChild(x, y)
     return super.isIn(x, y) || this.path.contains(dx, dy)
   }
 

--- a/packages/basic/src/widgets/figures/rect.ts
+++ b/packages/basic/src/widgets/figures/rect.ts
@@ -127,7 +127,7 @@ export class Rect extends Figure {
   }
 
   isIn(x: number, y: number): boolean {
-    const { x: dx, y: dy } = this.transformedPoint(x, y)
+    const { x: dx, y: dy } = this.coordinateParentToChild(x, y)
     return super.isIn(x, y) || this.path.contains(dx, dy)
   }
 

--- a/packages/basic/src/widgets/figures/rect.ts
+++ b/packages/basic/src/widgets/figures/rect.ts
@@ -131,10 +131,8 @@ export class Rect extends Figure {
     return super.isIn(x, y) || this.path.contains(dx, dy)
   }
 
-  get range(): WidgetRange {
-    return [
-      ...this.from,
-      ...this.to,
-    ]
+  calculateRange(): WidgetRange {
+    const bounds = this.path.computeTightBounds()
+    return [...bounds] as WidgetRange
   }
 }

--- a/packages/basic/src/widgets/imageWidget.ts
+++ b/packages/basic/src/widgets/imageWidget.ts
@@ -56,12 +56,12 @@ export class ImageWidget extends Widget {
     )
   }
 
-  get range(): WidgetRange {
+  calculateRange(): WidgetRange {
     return [
-      this.x,
-      this.y,
-      this.x + this.image.width(),
-      this.y + this.image.height(),
+      0,
+      0,
+      this.image.width(),
+      this.image.height(),
     ]
   }
 }

--- a/packages/basic/src/widgets/svg.ts
+++ b/packages/basic/src/widgets/svg.ts
@@ -84,12 +84,12 @@ export class Svg extends Widget {
       canvas.drawImage(this.imageData, this.x, this.y)
   }
 
-  get range(): WidgetRange {
+  calculateRange(): WidgetRange {
     return [
-      this.x,
-      this.y,
-      this.x + this.image.width,
-      this.y + this.image.height,
+      0,
+      0,
+      this.image.width,
+      this.image.height,
     ]
   }
 }

--- a/packages/basic/src/widgets/text.ts
+++ b/packages/basic/src/widgets/text.ts
@@ -468,12 +468,12 @@ export class Text extends Widget {
     return false
   }
 
-  get range(): WidgetRange {
+  calculateRange(): WidgetRange {
     return [
-      this.x,
-      this.y,
-      this.x + this.style.width,
-      this.y + this.paragraph.getHeight(),
+      0,
+      0,
+      this.style.width,
+      this.paragraph.getHeight(),
     ]
   }
 

--- a/packages/core/src/widget.ts
+++ b/packages/core/src/widget.ts
@@ -370,7 +370,7 @@ export class Widget {
   }
 
   isIn(x: number, y: number): boolean {
-    const { x: dx, y: dy } = this.transformedPoint(x, y)
+    const { x: dx, y: dy } = this.coordinateParentToChild(x, y)
     return this.children.some(child => child.isIn(dx, dy))
   }
 
@@ -379,7 +379,7 @@ export class Widget {
   }
 
   // transform the coordinate of the widget from parent to child considering the reRotation (mind the rotation center), reScale, and translation (mind widget.x and widget.y)
-  transformedPoint(x: number, y: number): { x: number, y: number } {
+  coordinateParentToChild(x: number, y: number): { x: number, y: number } {
     const centerX = this.centerX + this.x
     const centerY = this.centerY + this.y
     const relativeX = x - centerX

--- a/packages/core/src/widget.ts
+++ b/packages/core/src/widget.ts
@@ -374,8 +374,34 @@ export class Widget {
     return this.children.some(child => child.isIn(dx, dy))
   }
 
-  get range(): WidgetRange {
+  /**
+   * Calculate the range of the widget, based on the self coordinate.
+   * To be noted that this method should be overridden.
+   * @returns The range of the widget.
+   */
+  calculateRange(): WidgetRange {
     return [this.x, this.y, this.x, this.y]
+  }
+
+  /**
+   * The range of the widget, taking into account the children.
+   * To be noted that this method should not be overridden.
+   * @returns The range of the widget.
+   */
+  get range(): WidgetRange {
+    const calculatedRange = this.calculateRange()
+
+    const range = [
+      Math.min(...this.children.map(child => child.range[0]).concat(calculatedRange[0])),
+      Math.min(...this.children.map(child => child.range[1]).concat(calculatedRange[1])),
+      Math.max(...this.children.map(child => child.range[2]).concat(calculatedRange[2])),
+      Math.max(...this.children.map(child => child.range[3]).concat(calculatedRange[3])),
+    ]
+
+    const { x: x1, y: y1 } = this.coordinateChildToParent(range[0], range[1])
+    const { x: x2, y: y2 } = this.coordinateChildToParent(range[2], range[3])
+
+    return [x1, y1, x2, y2]
   }
 
   // transform the coordinate of the widget from parent to child considering the reRotation (mind the rotation center), reScale, and translation (mind widget.x and widget.y)
@@ -391,6 +417,20 @@ export class Widget {
     const newRelativeY = distance * Math.sin(newAngle)
     const newX = newRelativeX / this.style.scaleX + this.centerX
     const newY = newRelativeY / this.style.scaleY + this.centerY
+    return { x: newX, y: newY }
+  }
+
+  // transform the coordinate of the widget from child to parent considering the rotation, scale, and translation
+  coordinateChildToParent(x: number, y: number): { x: number, y: number } {
+    const relativeX = x - this.centerX
+    const relativeY = y - this.centerY
+    const newRelativeX = relativeX * this.style.scaleX
+    const newRelativeY = relativeY * this.style.scaleY
+    const distance = Math.sqrt(newRelativeX ** 2 + newRelativeY ** 2)
+    const angle = Math.atan2(newRelativeY, newRelativeX)
+    const newAngle = angle + this.style.rotation
+    const newX = distance * Math.cos(newAngle) + this.centerX + this.x
+    const newY = distance * Math.sin(newAngle) + this.centerY + this.y
     return { x: newX, y: newY }
   }
 


### PR DESCRIPTION
**Description:**
- refactor(core): `Widget.transformedPoint` to `Widget.coordinateParentToChild`
- feat(core): `Widget.coordinateChildToParent`
- feat(core): `Widget.range` default implementation
- feat(core): `Widget.calculateRange`
- feat: add `calculateRange` implementation for widgets with `path`

**Checklist:**

- [x]  Code has been reviewed
- [x]  Code complies with the project's code standards and best practices
- [x]  Code has passed all tests
- [x]  Code does not affect the normal use of existing features
- [x]  Documentation has been updated